### PR TITLE
review suggestions

### DIFF
--- a/docs/getting-started/config-examples/application-compute-part1-final.conf
+++ b/docs/getting-started/config-examples/application-compute-part1-final.conf
@@ -100,8 +100,10 @@ actions {
     type = CopyAction
     inputId = btl-departures-arrivals-airports
     outputId = btl-distances
-    transformer.class-name = com.sample.ComputeDistanceTransformer
-
+    transformers = [{
+      type = ScalaClassDfTransformer
+      className = com.sample.ComputeDistanceTransformer
+    }]
     metadata {
       feed = compute
     }

--- a/docs/getting-started/delta-lake-format.md
+++ b/docs/getting-started/delta-lake-format.md
@@ -88,6 +88,7 @@ Finally, adapt the action definition for `join-departures-airports`:
 To run our data pipeline, first delete the data directory - otherwise DeltaLakeTableDataObject will fail because of existing files in different format.
 Then you can execute the usual *docker run* command for all feeds:
 
+    mkdir -f data
     docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/config:/mnt/config smart-data-lake/gs1:latest -c /mnt/config --feed-sel 'download*'
     docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/config:/mnt/config smart-data-lake/gs1:latest -c /mnt/config --feed-sel '^(?!download).*'
 
@@ -115,7 +116,8 @@ We will now start Polynote in a docker container, and an external Metastore (Der
 To do so, run the following commands in the projects root directory:
     
     docker-compose build
-    mkdir -p data/_metastore
+    mkdir -f data
+    mkdir -f data/_metastore
     docker-compose up
 
 This might take multiple minutes.
@@ -123,14 +125,6 @@ You should now be able to access Polynote at `localhost:8192`.
 
 :::info Docker on Windows
 If you use Windows, please read our note on [Docker for Windows](docker-on-windows).
-
-
-If you encounter the following error on Windows:
-
-`ERROR [stage-1 4/5] RUN chmod +x install_spark.sh && ./install_spark.sh`
-
-that probably means that the file `install_spark.sh` got automatically converted to CRLF Line Endings on your machine.
-You can fix the Problem by converting the file to LF Line endings.
 :::
 
 But when you walk through the prepared notebook "SelectingData", you won't see any tables and data yet. 

--- a/docs/getting-started/delta-lake-format.md
+++ b/docs/getting-started/delta-lake-format.md
@@ -116,8 +116,7 @@ We will now start Polynote in a docker container, and an external Metastore (Der
 To do so, run the following commands in the projects root directory:
     
     docker-compose build
-    mkdir -f data
-    mkdir -f data/_metastore
+    mkdir -p data/_metastore
     docker-compose up
 
 This might take multiple minutes.

--- a/docs/getting-started/docker-on-windows.md
+++ b/docs/getting-started/docker-on-windows.md
@@ -29,5 +29,17 @@ Install podman-compose for podman in WSL2:
 After starting `podman-compose up` in the getting-started folder you should now be able to open Polynote on port localhost:8192, as WSL2 automatically publishes all ports on Windows.
 If the port is not accessible, you can use `wsl hostname -I` on Windows command line to get the IP adress of WSL, and then access Polynote over {ip-address}:8192.
 
+## Known Issue with podman on WSL2 on Windows
 
+If you suddenly cannot execute any podman commands anymore and get an error like this:
 
+    ERRO[0000] error joining network namespace for container 88a8d5c7115598aeaa31fcd1cee8c084fee3ab2577b4f61dc317053d7da032f9: error retrieving network namespace at /tmp/podman-run-1000/netns/cni-f73b0b0b-155d-3c43-30b2-278280c003f1: unknown FS magic on "/tmp/podman-run-1000/netns/cni-f73b0b0b-155d-3c43-30b2-278280c003f1": ef53
+    Error: error joining network namespace of container 88a8d5c7115598aeaa31fcd1cee8c084fee3ab2577b4f61dc317053d7da032f9: error retrieving network namespace at /tmp/podman-run-1000/netns/cni-f73b0b0b-155d-3c43-30b2-278280c003f1: unknown FS magic on "/tmp/podman-run-1000/netns/cni-f73b0b0b-155d-3c43-30b2-278280c003f1": ef53
+
+Then you may be experiencing a known problem with podman on WSL2 on windows after a system restart related to the /tmp directory.
+
+If you encounter this error, there are two quick workarounds:
+1. Delete the tmp dir of your WSL2 installation and restart WSL2
+2. The podman commands with sudo may still work, eg. `sudo podman ps` will work even if `podman ps` wont
+
+See https://github.com/containers/podman/issues/12236 for more information.


### PR DESCRIPTION
Here is my review of http://localhost:3000/sdl-docs/docs/getting-started/historical-data 
After I solved my problems with podman and docker it was nice to follow.

Just in the end the bit about Deduplication is a bit confusing. In the end, the DeduplicateAction didn't do anything by itself, apart from adding dl_ts_captured, right? I tried to add an example sentence to make it more clear. Maybe it would be even better to not use DeduplicateAction at all if it does not do what we want it do to...
And another thing that was a bit weird for me:

In the Doc of DeduplicateAction it says
*Deduplication keeps the last record for every key, also after it has been deleted in the source.
For me, this means that if I delete some records in stg_departures and run --feed-sel ids:deduplicate-departures again, I would expect to have two distinct entries in dl_ts_captured. That was not the case for me
 But maybe I misunderstand the doc ?

